### PR TITLE
fix:update flurry version to work with Xcode 14+

### DIFF
--- a/mParticle-Flurry.podspec
+++ b/mParticle-Flurry.podspec
@@ -16,12 +16,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Flurry/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Flurry-iOS-SDK/FlurrySDK', '~> 11.2'
+    s.ios.dependency 'Flurry-iOS-SDK/FlurrySDK', '~> 12.2'
+    s.static_framework = true
 
-    s.ios.pod_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-    s.ios.user_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
 end

--- a/mParticle-Flurry/MPKitFlurry.m
+++ b/mParticle-Flurry/MPKitFlurry.m
@@ -3,7 +3,7 @@
 #import "MPIHasher.h"
 #import "mParticle.h"
 #import "MPKitRegister.h"
-#import "Flurry.h"
+#import <Flurry_iOS_SDK/Flurry_iOS_SDK.h>
 #import "MPEnums.h"
 
 @implementation MPKitFlurry
@@ -43,8 +43,9 @@
         FlurrySessionBuilder* builder = [[[FlurrySessionBuilder new]
         withLogLevel:FlurryLogLevelCriticalOnly]
         withCrashReporting:crashReporting];
-        
+
         [Flurry startSession:self.configuration[@"apiKey"] withSessionBuilder:builder];
+        
     });
     
     self->_started = YES;


### PR DESCRIPTION
 ## Summary
 - A client reported that the Flurry kit is causing their app to break when running their app on Xcode 14.2 and I was able to reproduce the same behavior, it seems the older version of Flurry iOS SDK is not compatible with Xcode 14+ and it have not been updated in over 2 years. I updated the Flurry version in the podspec to the newest version and added the correct podspec flags/import statements.

 ## Testing Plan
 - Tested locally with having it as a local pod and seems to resolve the issue

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
