### PR TITLE
fix: Use Umbrella Imports

### DIFF
--- a/mParticle-Flurry/MPKitFlurry.h
+++ b/mParticle-Flurry/MPKitFlurry.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 @interface MPKitFlurry : NSObject <MPKitProtocol>


### PR DESCRIPTION
## Summary
 - MPIHasher was updated to a Swift class which required the umbrella header to imported rather than the old public header when not doing the module import. The majority of kits don't use MPIHasher so they aren't affected though we have created tickets to update them in the future.

 ## Testing Plan
 - Confirmed compilation and build then manually tested MPIHasher functionality once imported correctly

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/PRODRDMP-6099